### PR TITLE
Data series type to string * float and DataFlow constructor with series key

### DIFF
--- a/src/Sdmx/SdmxProvider.fs
+++ b/src/Sdmx/SdmxProvider.fs
@@ -41,11 +41,24 @@ type public SmdxProvider(cfg:TypeProviderConfig) as this =
                         let folder = fun state e -> <@@ (%%e:DimensionObject)::%%state @@>
                         let dims = List.fold folder <@@ []:List<DimensionObject> @@> args
                         <@@
-                            DataFlowObject(wsEntryPoint, dataId, %%dims)
+                            DataFlowObject(wsEntryPoint, dataId, "", %%dims)
                         @@>
                     )
             )
+                ProvidedConstructor(
+                    parameters = [
+                        yield ProvidedParameter("seriesKey", typeof<string>)
+                    ],
+                    invokeCode = ( fun args ->
+                        let seriesKey = <@@ (%%args.Head:string ) @@>
+                        <@@
+                            DataFlowObject(wsEntryPoint, dataId, %%seriesKey, [])
+                        @@>
+                    )
+            )
+
             dataflowsTypeDefinition.AddMember(dataCtor)
+            dataflowsTypeDefinition.AddMember(keyCtor)
             dataflowsTypeDefinition
 
         for dataflow in connection.Dataflows do


### PR DESCRIPTION
Changed data series type to string * float.

Added a constructor to data flows that takes a series key as string
as argument.

Added SeriesKey property to DataFlow.